### PR TITLE
fix: rename the Symfony command to "xezilaires:serialize"

### DIFF
--- a/src/Xezilaires/Bridge/Symfony/Command/SerializeCommand.php
+++ b/src/Xezilaires/Bridge/Symfony/Command/SerializeCommand.php
@@ -28,7 +28,7 @@ final class SerializeCommand extends Command
     /**
      * @var string
      */
-    protected static $defaultName = 'serialize';
+    protected static $defaultName = 'xezilaires:serialize';
 
     /**
      * @var SpreadsheetIteratorFactory
@@ -42,7 +42,7 @@ final class SerializeCommand extends Command
 
     public function __construct(SpreadsheetIteratorFactory $iteratorFactory, Serializer $serializer)
     {
-        parent::__construct('serialize');
+        parent::__construct('xezilaires:serialize');
 
         $this->setDescription('Serialize Excel files into JSON, XML, CSV');
 

--- a/src/Xezilaires/Bridge/Symfony/DependencyInjection/CompilerPass/RegisterCommandsCompilerPass.php
+++ b/src/Xezilaires/Bridge/Symfony/DependencyInjection/CompilerPass/RegisterCommandsCompilerPass.php
@@ -15,6 +15,8 @@ namespace Xezilaires\Bridge\Symfony\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Xezilaires\Bridge\Symfony\Command\SerializeCommand;
 
 /**
  * @internal
@@ -38,6 +40,19 @@ final class RegisterCommandsCompilerPass implements CompilerPassInterface
 
             if (0 !== mb_strpos($className, 'Xezilaires')) {
                 $container->removeDefinition($id);
+            }
+
+            if ($className === SerializeCommand::class) {
+                $arguments = $definition->getArguments();
+
+                $definition = new Definition($className);
+                $definition->setArguments($arguments);
+                $definition->addTag('console.command', [
+                    'command' => 'serialize',
+                ]);
+                $container->addDefinitions([
+                    $id => $definition,
+                ]);
             }
         }
     }


### PR DESCRIPTION
It avoids the possible namespace collision when used in an existing
Symfony app.

In bin/xezilaires, it stays named "serialize".

Closes #78.